### PR TITLE
Fixing nats-tls config for Windows to use hostname instead of IPs.

### DIFF
--- a/jobs/metrics-discovery-registrar-windows/monit
+++ b/jobs/metrics-discovery-registrar-windows/monit
@@ -1,14 +1,10 @@
 <%
-  nats_ips = link('nats-tls').instances.map { |instance| instance.address }
+  nats_host = "nats.service.cf.internal"
   nats_port = link('nats-tls').p("nats.port")
   nats_user = link('nats-tls').p("nats.user")
   nats_password = link('nats-tls').p("nats.password")
 
-  nats_hosts = nats_ips.map do |h|
-    "nats://#{nats_user}:#{nats_password}@#{h}:#{nats_port}"
-  end
-
-  nats_str = nats_hosts.join(",")
+  nats_str = "nats://#{nats_user}:#{nats_password}@#{nats_host}:#{nats_port}"
 
   certs_dir="/var/vcap/jobs/metrics-discovery-registrar-windows/config/certs"
 


### PR DESCRIPTION
Pull request as requested in https://github.com/cloudfoundry/metrics-discovery-release/issues/4.  Tested against cf-deployment v13.16.0.