### PR TITLE
Job deployed to nats connects to nats on own IP

### DIFF
--- a/jobs/metrics-discovery-registrar/spec
+++ b/jobs/metrics-discovery-registrar/spec
@@ -45,3 +45,6 @@ properties:
     description: "TLS certificate to communicate with the NATs server signed by the NATs CA"
   nats_client.key:
     description: "TLS private key to communicate with the NATs server signed by the NATs CA"
+  nats_instance_group:
+    description: "When deployed to this instance group, connect to the same instance via its IP address rather than via DNS lookup"
+    default: ""

--- a/jobs/metrics-discovery-registrar/templates/bpm.yml.erb
+++ b/jobs/metrics-discovery-registrar/templates/bpm.yml.erb
@@ -1,5 +1,9 @@
 <%
   nats_host = "nats.service.cf.internal"
+  if spec.name == p("nats_instance_group")
+    nats_host = "#{spec.id}.#{nats_host}"
+  end
+
   nats_port = link('nats-tls').p("nats.port")
   nats_user = link('nats-tls').p("nats.user")
   nats_password = link('nats-tls').p("nats.password")

--- a/jobs/metrics-discovery-registrar/templates/bpm.yml.erb
+++ b/jobs/metrics-discovery-registrar/templates/bpm.yml.erb
@@ -1,5 +1,5 @@
 <%
-  nats_host = "nats.service.cf.internal"
+  nats_host = link('nats-tls').p("nats.hostname")
   if spec.name == p("nats_instance_group")
     nats_host = "#{spec.id}.#{nats_host}"
   end


### PR DESCRIPTION
During upgrades, if previous deployment does not have nats-tls or the
metrics-discovery-registrar job at all, deployment can fail because
nats.service.cf.internal does not return any healthy instances to
connect that also have nats-tls running.

The first nats intance to deploy that would have that job running is not
healthy until the metrics-discovery-registrar is running. But
metrics-discovery-registrar has no nats-tls job it can resolve with
bosh-dns because the only instance that has nats-tls running is the
same, first nats instance. But that instance isn't healthy yet because
the metrics-discovery-registrar job isn't running yet... you get the
idea.

One way around this is to change the bosh-dns-aliases query from "*" to
"q-s4". But that means anyone locating nats will get unhealthy instances
in the mix. That may be acceptable given how nats clients retry
connections. But this change is more localized and addresses the root
cause more directly.

With this change, when nats_instance_group is configured, the
metrics-discovery-registrar jobs that get deployed to the instance group
of that name will connect to the nats job running on the same VM by IP
address instead of using bosh-dns to find a random instance. The new
property has no default, so if it is not set, the current behavior is
preserved.