### PR TITLE
Fix to Issue #9

### DIFF
--- a/jobs/metrics-discovery-registrar-windows/spec
+++ b/jobs/metrics-discovery-registrar-windows/spec
@@ -24,7 +24,7 @@ properties:
     default: 15s
   targets_glob:
     description: "Files matching the glob are expected to contain targets to Prometheus metrics endpoints"
-    default: "/var/vcap/**/**"
+    default: "/var/vcap/**/**/metric_targets.yml"
   target_refresh_interval:
     description: "Interval to refresh the Prometheus endpoint targets"
     default: 15s

--- a/jobs/metrics-discovery-registrar/spec
+++ b/jobs/metrics-discovery-registrar/spec
@@ -24,7 +24,7 @@ properties:
     default: 15s
   targets_glob:
     description: "Files matching the glob are expected to contain targets to Prometheus metrics endpoints"
-    default: "/var/vcap/**/**"
+    default: "/var/vcap/**/**/metric_targets.yml"
   target_refresh_interval:
     description: "Interval to refresh the Prometheus endpoint targets"
     default: 15s

--- a/jobs/metrics-discovery-registrar/templates/bpm.yml.erb
+++ b/jobs/metrics-discovery-registrar/templates/bpm.yml.erb
@@ -18,7 +18,7 @@
     "executable" => "/var/vcap/packages/metrics-discovery-registrar/discovery-registrar",
     "unsafe" => {
       "unrestricted_volumes" => [
-        { "path" => p("targets_glob"), "mount_only" => true },
+        { "path" => "/var/vcap/**/**", "mount_only" => true },
       ],
     },
     "env" => {


### PR DESCRIPTION
Previous PR #11 did not account for the fact that the target_glob in the spec was used in [multiple](https://github.com/cloudfoundry/metrics-discovery-release/blob/main/jobs/metrics-discovery-registrar/templates/bpm.yml.erb#L21) [places](https://github.com/cloudfoundry/metrics-discovery-release/blob/main/jobs/metrics-discovery-registrar/templates/bpm.yml.erb#L30). 
This commit rectifies that, and only edits the target glob in the [correct place](https://github.com/cloudfoundry/metrics-discovery-release/blob/main/jobs/metrics-discovery-registrar/templates/bpm.yml.erb#L21). This should help to solve some build and run issues when installing TAS 

Solves Issue #9 