### PR TITLE
Fix go vet errors

### DIFF
--- a/src/internal/target/target.go
+++ b/src/internal/target/target.go
@@ -1,7 +1,7 @@
 package target
 
 type Target struct {
-	Targets []string          `json:"targets",yaml:"targets"`
-	Labels  map[string]string `json:"labels",yaml:"labels"`
-	Source  string            `json:"-",yaml:"source"`
+	Targets []string          `json:"targets" yaml:"targets"`
+	Labels  map[string]string `json:"labels" yaml:"labels"`
+	Source  string            `json:"-" yaml:"source"`
 }


### PR DESCRIPTION
# Description

Fixes the following errors when running `go vet ./...` was failing in the `src` directory

```
# code.cloudfoundry.org/metrics-discovery/internal/target
internal/target/target.go:4:2: struct field tag `json:"targets",yaml:"targets"` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
internal/target/target.go:5:2: struct field tag `json:"labels",yaml:"labels"` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
internal/target/target.go:6:2: struct field tag `json:"-",yaml:"source"` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

