### PR TITLE
Fix `staticcheck` errors

### DIFF
--- a/src/cmd/config-generator/app/generator.go
+++ b/src/cmd/config-generator/app/generator.go
@@ -1,17 +1,18 @@
 package app
 
 import (
-	metrics "code.cloudfoundry.org/go-metric-registry"
-	"code.cloudfoundry.org/metrics-discovery/internal/registry"
-	"code.cloudfoundry.org/metrics-discovery/internal/target"
 	"encoding/json"
-	"github.com/nats-io/nats.go"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"log"
 	"os"
 	"sync"
 	"time"
+
+	metrics "code.cloudfoundry.org/go-metric-registry"
+	"code.cloudfoundry.org/metrics-discovery/internal/registry"
+	"code.cloudfoundry.org/metrics-discovery/internal/target"
+	"github.com/nats-io/nats.go"
+	"gopkg.in/yaml.v2"
 )
 
 type Subscriber func(queue string, callback nats.MsgHandler) (*nats.Subscription, error)
@@ -27,7 +28,6 @@ type ConfigGenerator struct {
 	done       chan struct{}
 	stop       chan struct{}
 	delivered  metrics.Counter
-	metrics    metricsRegistry
 	logger     *log.Logger
 
 	timestampedTargets map[string]timestampedTarget

--- a/src/cmd/discovery-registrar/app/registrar_test.go
+++ b/src/cmd/discovery-registrar/app/registrar_test.go
@@ -115,13 +115,6 @@ func (fp *fakePublisher) targets() [][]byte {
 	return dst
 }
 
-func (fp *fakePublisher) callsToPublish() int {
-	fp.Lock()
-	defer fp.Unlock()
-
-	return fp.called
-}
-
 func (fp *fakePublisher) publishedToQueue() string {
 	fp.Lock()
 	defer fp.Unlock()

--- a/src/internal/target/file_writer.go
+++ b/src/internal/target/file_writer.go
@@ -1,11 +1,12 @@
 package target
 
 import (
-	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/scraper"
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"log"
 	"os"
+
+	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/scraper"
+	"gopkg.in/yaml.v2"
 )
 
 type WriterConfig struct {
@@ -70,10 +71,8 @@ func appendScrapeConfigLabels(labels map[string]string, sc scraper.PromScraperCo
 func copyMap(original map[string]string) map[string]string {
 	copied := map[string]string{}
 
-	if original != nil {
-		for k, v := range original {
-			copied[k] = v
-		}
+	for k, v := range original {
+		copied[k] = v
 	}
 
 	return copied


### PR DESCRIPTION
# Description

Fixes the following errors received when running `staticcheck ./...` in the src directory

```
cmd/config-generator/app/generator.go:30:2: field metrics is unused (U1000)
cmd/discovery-registrar/app/registrar_test.go:118:26: func (*fakePublisher).callsToPublish is unused (U1000)
internal/gatherer/proxy_test.go:258:6: func counterWith is unused (U1000)
internal/gatherer/proxy_test.go:276:6: func getMetricsForFamily is unused (U1000)
internal/gatherer/proxy_test.go:299:7: const promOutput2 is unused (U1000)
internal/target/file_writer.go:73:2: unnecessary nil check around range (S1031)
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

