### PR TITLE
Don't report value of NATS_HOSTS environment variable

### DIFF
--- a/src/cmd/config-generator/app/config.go
+++ b/src/cmd/config-generator/app/config.go
@@ -8,13 +8,13 @@ import (
 )
 
 type Config struct {
-	NatsHosts                []string      `env:"NATS_HOSTS,              required, report"`
-	NatsCAPath               string        `env:"NATS_CA_PATH,            required, report"`
-	NatsCertPath             string        `env:"NATS_CERT_PATH,          required, report"`
-	NatsKeyPath              string        `env:"NATS_KEY_PATH,           required, report"`
+	NatsHosts                []string      `env:"NATS_HOSTS, required"`
+	NatsCAPath               string        `env:"NATS_CA_PATH, required, report"`
+	NatsCertPath             string        `env:"NATS_CERT_PATH, required, report"`
+	NatsKeyPath              string        `env:"NATS_KEY_PATH, required, report"`
 	ScrapeConfigFilePath     string        `env:"SCRAPE_CONFIG_FILE_PATH, required, report"`
-	ConfigExpirationInterval time.Duration `env:"CONFIG_EXPIRATION_INTERVAL,        report"`
-	ConfigTimeToLive         time.Duration `env:"CONFIG_TTL,                        report"`
+	ConfigExpirationInterval time.Duration `env:"CONFIG_EXPIRATION_INTERVAL, report"`
+	ConfigTimeToLive         time.Duration `env:"CONFIG_TTL, report"`
 	WriteFrequency           time.Duration `env:"WRITE_FREQUENCY, report"`
 
 	MetricsPort     int    `env:"METRICS_PORT, report"`

--- a/src/cmd/config-generator/app/config_test.go
+++ b/src/cmd/config-generator/app/config_test.go
@@ -1,0 +1,50 @@
+package app_test
+
+import (
+	"bytes"
+	"log"
+	"os"
+
+	"code.cloudfoundry.org/go-envstruct"
+	"code.cloudfoundry.org/metrics-discovery/cmd/config-generator/app"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("configuration", func() {
+
+	var requiredVars = []string{
+		"NATS_CA_PATH",
+		"NATS_CERT_PATH",
+		"NATS_KEY_PATH",
+		"SCRAPE_CONFIG_FILE_PATH",
+	}
+
+	BeforeEach(func() {
+		err := os.Setenv("NATS_HOSTS", "some-secret")
+		Expect(err).ToNot(HaveOccurred())
+
+		for _, v := range requiredVars {
+			err := os.Setenv(v, "some-value")
+			Expect(err).ToNot(HaveOccurred())
+		}
+	})
+	AfterEach(func() {
+		err := os.Unsetenv("NATS_HOSTS")
+		Expect(err).ToNot(HaveOccurred())
+
+		for _, v := range requiredVars {
+			err := os.Unsetenv(v)
+			Expect(err).ToNot(HaveOccurred())
+		}
+	})
+
+	It("does not report the value of the NATS_HOSTS environment variable", func() {
+		var output bytes.Buffer
+		envstruct.ReportWriter = &output
+		logger := log.New(GinkgoWriter, "", log.LstdFlags)
+		app.LoadConfig(logger)
+		Expect(output.String()).ToNot(ContainSubstring("some-secret"))
+	})
+
+})

--- a/src/cmd/discovery-registrar/app/config.go
+++ b/src/cmd/discovery-registrar/app/config.go
@@ -8,13 +8,13 @@ import (
 )
 
 type Config struct {
-	PublishInterval time.Duration `env:"PUBLISH_INTERVAL,                 report"`
-	NatsHosts       []string      `env:"NATS_HOSTS,             required, report"`
-	NatsCAPath      string        `env:"NATS_CA_PATH,           required, report"`
-	NatsCertPath    string        `env:"NATS_CERT_PATH,           required, report"`
-	NatsKeyPath     string        `env:"NATS_KEY_PATH,           required, report"`
+	PublishInterval time.Duration `env:"PUBLISH_INTERVAL, report"`
+	NatsHosts       []string      `env:"NATS_HOSTS, required"`
+	NatsCAPath      string        `env:"NATS_CA_PATH, required, report"`
+	NatsCertPath    string        `env:"NATS_CERT_PATH, required, report"`
+	NatsKeyPath     string        `env:"NATS_KEY_PATH, required, report"`
 
-	TargetsGlob           string        `env:"TARGETS_GLOB,            report"`
+	TargetsGlob           string        `env:"TARGETS_GLOB, report"`
 	TargetRefreshInterval time.Duration `env:"TARGET_REFRESH_INTERVAL, report"`
 
 	MetricsCAPath   string `env:"METRICS_CA_PATH, required, report"`


### PR DESCRIPTION
# Description

Modifies the reporting of environment variables on startup to not include the value of the `NATS_HOSTS` environment variable.

The unit tests added modify environment variables.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [X] Unit tests
- [X] Integration tests
- [ ] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [X] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
