### PR TITLE
Replace `ioutil` use with `io` and `os`

### DIFF
--- a/src/cmd/config-generator/app/generator.go
+++ b/src/cmd/config-generator/app/generator.go
@@ -3,7 +3,6 @@ package app
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	_ "net/http/pprof" // nolint:gosec
@@ -153,7 +152,7 @@ func (cg *ConfigGenerator) writeConfigToFile() {
 		return
 	}
 
-	err = ioutil.WriteFile(cg.path, data, os.ModePerm)
+	err = os.WriteFile(cg.path, data, os.ModePerm)
 	if err != nil {
 		cg.logger.Printf("failed to write scrape config file: %s\n", err)
 	}

--- a/src/cmd/config-generator/app/generator_test.go
+++ b/src/cmd/config-generator/app/generator_test.go
@@ -2,9 +2,9 @@ package app_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"time"
 
 	"code.cloudfoundry.org/go-metric-registry/testhelpers"
@@ -23,7 +23,7 @@ var _ = Describe("Config generator", func() {
 	}
 
 	var setup = func() *testContext {
-		tmpDir, err := ioutil.TempDir("", "")
+		tmpDir, err := os.MkdirTemp("", "")
 		Expect(err).ToNot(HaveOccurred())
 
 		return &testContext{
@@ -37,7 +37,7 @@ var _ = Describe("Config generator", func() {
 		var fileData []byte
 
 		Eventually(func() string {
-			fileData, _ = ioutil.ReadFile(tc.configPath)
+			fileData, _ = os.ReadFile(tc.configPath)
 
 			return string(fileData)
 		}).ShouldNot(Equal(""))
@@ -109,7 +109,7 @@ var _ = Describe("Config generator", func() {
 		})
 
 		Consistently(func() error {
-			_, err := ioutil.ReadFile(tc.configPath)
+			_, err := os.ReadFile(tc.configPath)
 			return err
 		}).ShouldNot(Succeed())
 	})

--- a/src/cmd/config-generator/main.go
+++ b/src/cmd/config-generator/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"log"
 	"os"
 	"time"
@@ -57,7 +56,7 @@ func main() {
 }
 
 func getTLSConfig(cfg app.Config) *tls.Config {
-	caCert, err := ioutil.ReadFile(cfg.NatsCAPath)
+	caCert, err := os.ReadFile(cfg.NatsCAPath)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/src/cmd/discovery-registrar/main.go
+++ b/src/cmd/discovery-registrar/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/signal"
@@ -63,7 +62,7 @@ func connectToNATS(cfg app.Config, logger *log.Logger) *nats.Conn {
 }
 
 func getTLSConfig(cfg app.Config) *tls.Config {
-	caCert, err := ioutil.ReadFile(cfg.NatsCAPath)
+	caCert, err := os.ReadFile(cfg.NatsCAPath)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/src/cmd/metrics-agent/app/metrics_agent_test.go
+++ b/src/cmd/metrics-agent/app/metrics_agent_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -108,7 +107,7 @@ var _ = Describe("MetricsAgent", func() {
 		go metricsAgent.Run()
 		waitForMetricsEndpoint(metricsPort, testCerts)
 
-		f, err := ioutil.ReadFile(targetsFile)
+		f, err := os.ReadFile(targetsFile)
 		Expect(err).ToNot(HaveOccurred())
 
 		var targets []target.Target

--- a/src/internal/gatherer/proxy.go
+++ b/src/internal/gatherer/proxy.go
@@ -3,7 +3,6 @@ package gatherer
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"strings"
@@ -108,12 +107,12 @@ func (c *ProxyGatherer) scrape(scrapeConfig scraper.PromScraperConfig) ([]*io_pr
 	}
 
 	defer func() {
-		_, _ = io.Copy(ioutil.Discard, resp.Body)
+		_, _ = io.Copy(io.Discard, resp.Body)
 		resp.Body.Close()
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("unexpected status code %d: %s", resp.StatusCode, body)
 	}
 

--- a/src/internal/target/file_provider.go
+++ b/src/internal/target/file_provider.go
@@ -1,8 +1,8 @@
 package target
 
 import (
-	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -48,7 +48,7 @@ func (fp *fileProvider) populateTargets() {
 	}
 
 	for _, f := range files {
-		yamlFile, err := ioutil.ReadFile(f)
+		yamlFile, err := os.ReadFile(f)
 		if err != nil {
 			fp.logger.Printf("cannot read file: %s", err)
 			continue

--- a/src/internal/target/file_provider_test.go
+++ b/src/internal/target/file_provider_test.go
@@ -2,7 +2,6 @@ package target_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"time"
@@ -79,12 +78,12 @@ var _ = Describe("FileProvider", func() {
 })
 
 func targetConfigFile(fileName string) *os.File {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	f, err := ioutil.TempFile(dir, fileName)
+	f, err := os.CreateTemp(dir, fileName)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/src/internal/target/file_writer_test.go
+++ b/src/internal/target/file_writer_test.go
@@ -1,7 +1,6 @@
 package target_test
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -46,7 +45,7 @@ var _ = Describe("File Writer", func() {
 	}
 
 	var readTargetsFromFile = func(tc *testContext) []target.Target {
-		f, err := ioutil.ReadFile(tc.targetsFile)
+		f, err := os.ReadFile(tc.targetsFile)
 		Expect(err).ToNot(HaveOccurred())
 
 		var targets []target.Target

--- a/src/internal/testhelpers/certificate.go
+++ b/src/internal/testhelpers/certificate.go
@@ -1,8 +1,8 @@
 package testhelpers
 
 import (
-	"io/ioutil"
 	"log"
+	"os"
 
 	"code.cloudfoundry.org/tlsconfig/certtest"
 )
@@ -68,7 +68,7 @@ func generateCA(caName string) (*certtest.Authority, string) {
 }
 
 func tmpFile(prefix string, caBytes []byte) string {
-	file, err := ioutil.TempFile("", prefix)
+	file, err := os.CreateTemp("", prefix)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
# Description

"io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
