### PR TITLE
Fix: failing file writer test

### DIFF
--- a/src/internal/target/file_writer_test.go
+++ b/src/internal/target/file_writer_test.go
@@ -19,8 +19,12 @@ var _ = Describe("File Writer", func() {
 		tmpDir     string
 	)
 
-	JustBeforeEach(func() {
+	BeforeEach(func() {
+		scrapeCfgs = []scraper.PromScraperConfig{}
 		tmpDir = GinkgoT().TempDir()
+	})
+
+	JustBeforeEach(func() {
 		cfg := target.WriterConfig{
 			MetricsHost: host,
 			DefaultLabels: map[string]string{


### PR DESCRIPTION
# Description

After a ginkgo/gomega bump, this test started failing. Appeared to have been due to a change where when that test was run in parallel, the shared scrapeCfgs variable wasn't being reset across processes, so tests that expected them to be blank were failing.

Add a BeforeEach node to rest scrapeCfgs to an empty slice.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
