### PR TITLE
add disable flag to metrics-agent & metrics-discovery-registrar

### DIFF
--- a/jobs/metrics-agent-windows/monit
+++ b/jobs/metrics-agent-windows/monit
@@ -44,9 +44,10 @@
     process["env"]["SCRAPE_KEY_PATH"] = "#{certs_dir}/scrape.key"
   }
 
-  monit = {
-    "processes" => [process]
-  }
+  monit = { "processes" => [] }
+  unless p('disable')
+    monit["processes"] = [process]
+  end
 %>
 
 <%= JSON.pretty_generate(monit) %>

--- a/jobs/metrics-agent-windows/spec
+++ b/jobs/metrics-agent-windows/spec
@@ -19,6 +19,10 @@ packages:
 - metrics-agent-windows
 
 properties:
+  disable:
+    description: "Disable this job so that it will not run"
+    default: false
+
   port:
     description: "Port the agent is serving gRPC via mTLS"
     default: 3461

--- a/jobs/metrics-agent/monit
+++ b/jobs/metrics-agent/monit
@@ -1,5 +1,7 @@
+<% unless p("disable") %>
 check process metrics-agent
   with pidfile /var/vcap/sys/run/bpm/metrics-agent/metrics-agent.pid
   start program "/var/vcap/jobs/bpm/bin/bpm start metrics-agent"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop metrics-agent"
   group vcap
+<% end %>

--- a/jobs/metrics-agent/spec
+++ b/jobs/metrics-agent/spec
@@ -20,6 +20,10 @@ packages:
 - metrics-agent
 
 properties:
+  disable:
+    description: "Disable this job so that it will not run"
+    default: false
+
   port:
     description: "Port the agent is serving gRPC via mTLS"
     default: 3461

--- a/jobs/metrics-discovery-registrar-windows/monit
+++ b/jobs/metrics-discovery-registrar-windows/monit
@@ -24,16 +24,17 @@
     "PPROF_PORT" => "#{p("metrics.pprof_port")}",
   }
 
-  monit = {
-    "processes" => [
-      {
+  process = {
         "name" => "metrics-discovery-registrar-windows",
         "executable" => "/var/vcap/packages/metrics-discovery-registrar-windows/discovery-registrar.exe",
         "args" => [],
         "env" => env
-      }
-    ]
   }
+
+  monit = { "processes" => [] }
+  unless p('disable')
+    monit["processes"] = [process]
+  end
 %>
 
 <%= JSON.pretty_generate(monit) %>

--- a/jobs/metrics-discovery-registrar-windows/spec
+++ b/jobs/metrics-discovery-registrar-windows/spec
@@ -19,6 +19,10 @@ packages:
 - metrics-discovery-registrar-windows
 
 properties:
+  disable:
+    description: "Disable this job so that it will not run"
+    default: false
+
   publish_interval:
     description: "Interval to publish targets"
     default: 15s

--- a/jobs/metrics-discovery-registrar/monit
+++ b/jobs/metrics-discovery-registrar/monit
@@ -1,5 +1,7 @@
+<% unless p("disable") %>
 check process metrics-discovery-registrar
   with pidfile /var/vcap/sys/run/bpm/metrics-discovery-registrar/metrics-discovery-registrar.pid
   start program "/var/vcap/jobs/bpm/bin/bpm start metrics-discovery-registrar"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop metrics-discovery-registrar"
   group vcap
+<% end %>

--- a/jobs/metrics-discovery-registrar/spec
+++ b/jobs/metrics-discovery-registrar/spec
@@ -19,6 +19,10 @@ packages:
 - metrics-discovery-registrar
 
 properties:
+  disable:
+    description: "Disable this job so that it will not run"
+    default: false
+
   publish_interval:
     description: "Interval to publish targets"
     default: 15s


### PR DESCRIPTION
Adding the ability to disable these jobs via a property as we are working towards deprecating them.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

