### PR TITLE
Don't configure prom scraper when disabled

### DIFF
--- a/jobs/metrics-agent-windows/templates/prom_scraper_config.yml.erb
+++ b/jobs/metrics-agent-windows/templates/prom_scraper_config.yml.erb
@@ -1,6 +1,8 @@
+<% unless p('disable') %>
 ---
 port: <%= p("metrics.port") %>
 source_id: "metrics-agent"
 instance_id: <%= spec.id || spec.index.to_s %>
 scheme: https
 server_name: <%= p('metrics.server_name') %>
+<% end %>

--- a/jobs/metrics-agent/templates/prom_scraper_config.yml.erb
+++ b/jobs/metrics-agent/templates/prom_scraper_config.yml.erb
@@ -1,6 +1,8 @@
+<% unless p('disable') %>
 ---
 port: <%= p("metrics.port") %>
 source_id: "metrics-agent"
 instance_id: <%= spec.id || spec.index.to_s %>
 scheme: https
 server_name: <%= p('metrics.server_name') %>
+<% end %>

--- a/jobs/metrics-discovery-registrar-windows/templates/prom_scraper_config.yml.erb
+++ b/jobs/metrics-discovery-registrar-windows/templates/prom_scraper_config.yml.erb
@@ -1,6 +1,8 @@
+<% unless p('disable') %>
 ---
 port: <%= p("metrics.port") %>
 source_id: "metrics_discovery_registrar"
 instance_id: <%= spec.id || spec.index.to_s %>
 scheme: https
 server_name: <%= p('metrics.server_name') %>
+<% end %>

--- a/jobs/metrics-discovery-registrar/templates/prom_scraper_config.yml.erb
+++ b/jobs/metrics-discovery-registrar/templates/prom_scraper_config.yml.erb
@@ -1,6 +1,8 @@
+<% unless p('disable') %>
 ---
 port: <%= p("metrics.port") %>
 source_id: "metrics_discovery_registrar"
 instance_id: <%= spec.id || spec.index.to_s %>
 scheme: https
 server_name: <%= p('metrics.server_name') %>
+<% end %>


### PR DESCRIPTION
# Description

Don't render config for prom scraper when jobs are disabled.

This avoids the prom scraper attempting to scrape jobs that are not running.

Fixes:

```
2023-09-28T01:31:33.050662911Z failed to scrape: scrape errors:
  [id: metrics-agent, instance_id: 80e33056-f0bd-4699-9238-c65da1481cde, metric_url: https://127.0.0.1:14727/metrics]: Get "https://127.0.0.1:14727/metrics": dial tcp 127.0.0.1:14727: connect: connection refused
2023-09-28T01:31:33.052771260Z failed to scrape: scrape errors:
  [id: metrics_discovery_registrar, instance_id: 80e33056-f0bd-4699-9238-c65da1481cde, metric_url: https://127.0.0.1:15821/metrics]: Get "https://127.0.0.1:15821/metrics": dial tcp 127.0.0.1:15821: connect: connection refused
```

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

We performed some manual testing.

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
