### PR TITLE
Add ops file to add latest release to cf-d

### DIFF
--- a/manifests/operations/use-latest-release.yml
+++ b/manifests/operations/use-latest-release.yml
@@ -1,0 +1,87 @@
+---
+- type: replace
+  path: /releases/name=metrics-discovery?
+  value:
+    name: metrics-discovery
+    version: latest
+    url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release
+- type: replace
+  path: /addons/name=metrics-discovery-registrar?
+  value:
+    name: metrics-discovery-registrar
+    exclude:
+      jobs:
+      - name: smoke_tests
+        release: cf-smoke-tests
+    include:
+      stemcell:
+      - os: ubuntu-bionic
+      - os: ubuntu-jammy
+    jobs:
+    - name: metrics-discovery-registrar
+      properties:
+        metrics:
+          ca_cert: ((metrics_discovery_metrics_tls.ca))
+          cert: ((metrics_discovery_metrics_tls.certificate))
+          key: ((metrics_discovery_metrics_tls.private_key))
+          server_name: metrics_discovery_metrics
+        nats_client:
+          cert: ((nats_client_cert.certificate))
+          key: ((nats_client_cert.private_key))
+      release: metrics-discovery
+- type: replace
+  path: /addons/name=metrics-agent?
+  value:
+    name: metrics-agent
+    exclude:
+      jobs:
+      - name: smoke_tests
+        release: cf-smoke-tests
+    include:
+      stemcell:
+      - os: ubuntu-bionic
+      - os: ubuntu-jammy
+    jobs:
+    - name: metrics-agent
+      properties:
+        grpc:
+          ca_cert: ((loggregator_tls_agent.ca))
+          cert: ((loggregator_tls_agent.certificate))
+          key: ((loggregator_tls_agent.private_key))
+        metrics:
+          ca_cert: ((metrics_agent_tls.ca))
+          cert: ((metrics_agent_tls.certificate))
+          key: ((metrics_agent_tls.private_key))
+          server_name: metrics_agent
+        scrape:
+          tls:
+            ca_cert: ((prom_scraper_scrape_tls.ca))
+            cert: ((prom_scraper_scrape_tls.certificate))
+            key: ((prom_scraper_scrape_tls.private_key))
+      release: metrics-discovery
+- type: replace
+  path: /variables/name=metrics_agent_tls?
+  value:
+    name: metrics_agent_tls
+    type: certificate
+    update_mode: converge
+    options:
+      ca: metric_scraper_ca
+      common_name: metrics_agent
+      alternative_names:
+      - metrics_agent
+      extended_key_usage:
+      - server_auth
+- type: replace
+  path: /variables/name=metrics_discovery_tls?
+  value:
+    name: metrics_discovery_metrics_tls
+    type: certificate
+    update_mode: converge
+    options:
+      ca: metric_scraper_ca
+      common_name: metrics_discovery_metrics
+      alternative_names:
+      - metrics_discovery_metrics
+      extended_key_usage:
+      - server_auth


### PR DESCRIPTION
# Description

Since this repo is deprecated, we removed metrics-discovery release from CF-D. This caused our testing jobs in the metrics-discovery pipeline are failing to deploy with this error:
```
Error 'operation [0] in create-provided-release.yml failed': Expected to find exactly one matching array item for path '/releases/name=metrics-discovery' but found 0
```

This  ops file puts metrics-discovery back into CF-D.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
