### PR TITLE
Restrict generated scrape target file permission

### DIFF
--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -17,3 +17,9 @@ issues:
   max-issues-per-linter: 0
   # Disable max same issues.
   max-same-issues: 0
+  # Allow more permissive file permissions on the generated scrape target file only.
+  exclude-rules:
+  - path: cmd/config-generator/app/generator.go
+    text: "G306: Expect WriteFile permissions to be 0600 or less"
+    linters:
+    - gosec

--- a/src/cmd/config-generator/app/generator.go
+++ b/src/cmd/config-generator/app/generator.go
@@ -152,7 +152,7 @@ func (cg *ConfigGenerator) writeConfigToFile() {
 		return
 	}
 
-	err = os.WriteFile(cg.path, data, os.ModePerm)
+	err = os.WriteFile(cg.path, data, 0644)
 	if err != nil {
 		cg.logger.Printf("failed to write scrape config file: %s\n", err)
 	}

--- a/src/cmd/config-generator/app/generator_test.go
+++ b/src/cmd/config-generator/app/generator_test.go
@@ -85,6 +85,10 @@ var _ = Describe("Config generator", func() {
 				}
 			}
 		]`))
+
+		fi, err := os.Stat(tc.configPath)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(fi.Mode()).To(BeNumerically("==", 0644))
 	})
 
 	It("generates the config at the given interval", func() {


### PR DESCRIPTION
# Description

Restricted generated scrape target file permission and kept it accessible by other processes in the box not running under the user `vcap`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [x] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
